### PR TITLE
HOTFix  for iOS 13 crash

### DIFF
--- a/Source/SideMenuController.swift
+++ b/Source/SideMenuController.swift
@@ -287,7 +287,13 @@ open class SideMenuController: UIViewController, UIGestureRecognizerDelegate {
             return
         }
         
-        sbw?.set(hidden, withBehaviour: _preferences.animating.statusBarBehaviour)
+         if #available(iOS 13, *) {
+                   //TODO: add code for iOS 13 version
+         }
+         else
+         {
+               sbw?.set(hidden, withBehaviour: _preferences.animating.statusBarBehaviour)
+         }
         
         if _preferences.animating.statusBarBehaviour == StatusBarBehaviour.horizontalPan {
             if !hidden {
@@ -419,6 +425,12 @@ open class SideMenuController: UIViewController, UIGestureRecognizerDelegate {
     // MARK: - Computed variables -
     
     fileprivate var sbw: UIWindow? {
+        
+        // statusBarWindow is not available any more in  iOS 13+
+         
+        if #available(iOS 13, *) {
+             return nil
+         }
         
         let s = "status"
         let b = "Bar"


### PR DESCRIPTION
Application crashed before on each side menu closing on IOS 13 + with error:

'NSInternalInconsistencyException', reason: 'App called -statusBar or -statusBarWindow on UIApplication: this code must be changed as there's no longer a status bar or status bar window. Use the statusBarManager object on the window scene instead.’